### PR TITLE
Trust 592 clear logs

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.1"
+    version: "1.0.2"
   analyzer:
     dependency: transitive
     description:

--- a/lib/src/appenders/file_log_appender/controllers/meta_data_controller.dart
+++ b/lib/src/appenders/file_log_appender/controllers/meta_data_controller.dart
@@ -15,11 +15,6 @@ class MetaDataController {
   /// The default name of the metadata file used for storing metadata.
   static const String metadataDefaultName = '.metadata';
 
-  /// A subscription to the stream that controls debounced flush operations.
-  /// This ensures that metadata changes are written to disk only after a
-  /// specified delay to avoid excessive disk writes.
-  late StreamSubscription _flushSub;
-
   /// The debounce duration that defines the delay between metadata updates
   /// and the actual write operation. This helps in bundling multiple changes
   /// into a single disk write.
@@ -113,7 +108,6 @@ class MetaDataController {
   /// This method should be called when the `MetaDataManager` is no longer needed
   /// to ensure that all pending writes are completed.
   Future<void> dispose() async {
-    await _flushSub.cancel();
     await _flushController.close();
   }
 }

--- a/lib/src/appenders/file_log_appender/controllers/meta_data_controller.dart
+++ b/lib/src/appenders/file_log_appender/controllers/meta_data_controller.dart
@@ -88,6 +88,13 @@ class MetaDataController {
     _flush(metadata);
   }
 
+  /// Clears all metadata from memory and schedules a flush to write an empty
+  /// list to disk, effectively resetting the metadata file.
+  void clearAll() {
+    _buffer = [];
+    _flushController.add([]);
+  }
+
   /// Triggers a flush (write) operation by adding the updated metadata to the
   /// flush stream. The data will be written to disk after the debounce delay.
   ///

--- a/lib/src/appenders/file_log_appender/file_log_appender.dart
+++ b/lib/src/appenders/file_log_appender/file_log_appender.dart
@@ -118,7 +118,7 @@ class FileLogAppender extends BaseLogAppender {
     final metadataPath = splitPath.join(PlatformPathUtil.platformSeparator);
     List<LogMetaData> metaData = await _logStorage.readMetaData(metadataPath) ?? [];
     final path = splitPath.join(PlatformPathUtil.platformSeparator);
-    
+
     if (metaData.isNotEmpty) {
       final directory = path.replaceAll('.metadata', '');
       final existingFiles = (await _logStorage.readFileNames(directory)).map((e) => basename(e)).toSet();
@@ -246,6 +246,51 @@ class FileLogAppender extends BaseLogAppender {
 
     _flushSub?.resume();
     return rotatedFile;
+  }
+
+  /// Clears all log files and resets the metadata.
+  ///
+  /// Deletes every rotated log file and the current log file from storage,
+  /// clears the in-memory metadata buffer, writes an empty metadata file,
+  /// and resets the rotation capacity tracker.
+  Future<void> clearAllLogs() async {
+    // Ensure initialization is complete.
+    if (_flushSub == null) {
+      await _initializationCache.fetch(_init);
+    }
+
+    // Pause the flush subscription to prevent concurrent writes during cleanup.
+    _flushSub?.pause();
+
+    try {
+      final metaData = _metaDataController!.fetchMetadata();
+
+      // Collect all rotated log file paths.
+      final rotatedPaths = _rotationFileController.getRotatedPaths(filePath, metaData.map((el) => el.id).toList());
+
+      // Delete all rotated log files.
+      await Future.wait(rotatedPaths.map((path) => _logStorage.deleteData(path)));
+
+      // Delete the current log file.
+      await _logStorage.deleteData(filePath);
+
+      // Reset the rotation capacity tracker.
+      final totalCapacity = metaData.fold<int>(0, (sum, e) => sum + e.lengthInBytes);
+      _rotationFileController.updateCapacity(-totalCapacity);
+
+      // Delete the metadata file from storage.
+      await _logStorage.deleteData(_metaDataController!.path);
+
+      // Cancel the old metadata subscription and dispose the old controller.
+      await _metadataSub?.cancel();
+      await _metaDataController!.dispose();
+
+      // Create a fresh metadata controller with no initial data.
+      _metaDataController = MetaDataController(_metaDataController!.path);
+      _metadataSub = _metaDataController!.listen(_onMetadataUpdated);
+    } finally {
+      _flushSub?.resume();
+    }
   }
 
   /// Closes the current write sink and cancels the debounce timer.


### PR DESCRIPTION
## Summary

Add `FileLogAppender.clearAllLogs()` — a public method to delete all log files and reset the metadata file. Also fix a latent `LateInitializationError` in `MetaDataController.dispose()`.

## Changes

### `FileLogAppender`

- **Added `clearAllLogs()`** — performs a full cleanup:
  1. Pauses the flush subscription to prevent concurrent writes
  2. Deletes all rotated log files from storage
  3. Deletes the current log file
  4. Resets the rotation capacity tracker to zero
  5. Deletes the .metadata file from storage
  6. Cancels the old metadata subscription and disposes the old controller
  7. Creates a fresh `MetaDataController` with empty initial data
  8. Resumes the flush subscription in a `finally` block

### `MetaDataController`

- **Added `clearAll()`** — clears the in-memory buffer and schedules a flush of an empty list to disk
- **Removed unused `_flushSub` field** — it was declared `late` but never initialized (`listen()` returns the subscription to the caller, it doesn't store it internally), causing a `LateInitializationError` on `dispose()`
- **Simplified `dispose()`** — now only closes `_flushController`

## Motivation

The logger previously had no way to programmatically clear all accumulated logs and reset state. This is needed for scenarios like "clear logs" user actions or reinitializing the logging subsystem.

## How to test

```dart
final appender = FileLogAppender(
  filePath: '/path/to/logs/app',
  logStorage: FileLogStorage(),
);

// ... some logging ...

await appender.clearAllLogs();
// All log files and the .metadata file are now deleted.
// The appender is ready to accept new log records.
```

## Affected files

| File | Change |
|------|--------|
| file_log_appender.dart | Added `clearAllLogs()` |
| meta_data_controller.dart | Added `clearAll()`, removed `_flushSub`, simplified `dispose()` |